### PR TITLE
[FIX] property_fiscal_classification setted invisible 

### DIFF
--- a/account_product_fiscal_classification/product_view.xml
+++ b/account_product_fiscal_classification/product_view.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <group name="properties" position="before">
                     <group string="Fiscal Properties" col="4" colspan="4">
-                        <field name="property_fiscal_classification" colspan="4" attrs="{'required': [('type', '!=', 'service')]}" select="2" on_change="fiscal_classification_id_change(property_fiscal_classification, taxes_id, supplier_taxes_id, context)"/>
+                        <field name="property_fiscal_classification" colspan="4" invisible="1" attrs="{'required': [('type', '!=', 'service')]}" select="2" on_change="fiscal_classification_id_change(property_fiscal_classification, taxes_id, supplier_taxes_id, context)"/>
                     </group>
                 </group>
             </field>


### PR DESCRIPTION
O campo property_fiscal_classification é igual ao campo ncm_id do modulo l10n_br_account_product(mesmo funcionamento, onchange, etc),
e como é um campo do tipo property ele só é valido em multicompany. Porém não é necessário estar na view de empresas unicas (caso mais provavel, portanto seria melhor estar fora da view  adicionado caso a empresa seja multicompany).
Talvez seria uma boa idéia verificar se é possivel criar um onchange no ncm_id para copiar o seu valor para o property_fiscal_classification por questões de compatibilidade com multicompany.
